### PR TITLE
Move core initialization to load_game for better ergonomics

### DIFF
--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "example"
 version = "0.1.0"
-authors = ["Adam Becker <im.adam.becker@gmail.com>"]
+authors = ["Adam Becker <apbecker@protonmail.com>"]
 edition = "2021"
 
 [dependencies]

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -3,14 +3,6 @@ use libretro_rs::*;
 pub struct Emulator;
 
 impl RetroCore for Emulator {
-  fn init(env: &RetroEnvironment) -> Self {
-    let system_dir = env.get_system_directory().unwrap_or("~/.config/emulator");
-
-    println!("[libretro_rs] new(). system_dir={}", system_dir);
-
-    Emulator
-  }
-
   fn get_system_info() -> RetroSystemInfo {
     println!("[libretro_rs] get_system_info()");
 
@@ -29,7 +21,10 @@ impl RetroCore for Emulator {
     println!("[libretro_rs] run()");
   }
 
-  fn load_game(&mut self, _: &RetroEnvironment, game: RetroGame) -> RetroLoadGameResult {
+  fn load_game(env: &RetroEnvironment, game: RetroGame) -> RetroLoadGameResult<Self> {
+    let system_dir = env.get_system_directory().unwrap_or("~/.config/emulator");
+    println!("[libretro_rs] load_game(). system_dir={}", system_dir);
+
     match game {
       RetroGame::None { .. } => {
         println!("[libretro_rs] load_game()");
@@ -47,6 +42,7 @@ impl RetroCore for Emulator {
       region: RetroRegion::NTSC,
       audio: RetroAudioInfo::new(44_100.0),
       video: RetroVideoInfo::new(60.0, 256, 240),
+      core: Emulator,
     }
   }
 }

--- a/libretro-rs-sys/Cargo.toml
+++ b/libretro-rs-sys/Cargo.toml
@@ -1,6 +1,9 @@
 [package]
 name = "libretro-rs-sys"
+repository = "https://github.com/libretro-rs/libretro-rs"
+license = "MIT/Apache-2.0"
 version = "0.1.0"
+authors = ["Adam Becker <apbecker@protonmail.com>"]
 edition = "2021"
 
 [dependencies]

--- a/libretro-rs/Cargo.toml
+++ b/libretro-rs/Cargo.toml
@@ -4,7 +4,7 @@ description = "High-level abstractions for the libretro API"
 readme = "README.md"
 repository = "https://github.com/libretro-rs/libretro-rs"
 license = "MIT/Apache-2.0"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Adam Becker <im.adam.becker@gmail.com>"]
 edition = "2021"
 

--- a/libretro-rs/Cargo.toml
+++ b/libretro-rs/Cargo.toml
@@ -4,8 +4,8 @@ description = "High-level abstractions for the libretro API"
 readme = "README.md"
 repository = "https://github.com/libretro-rs/libretro-rs"
 license = "MIT/Apache-2.0"
-version = "0.2.0"
-authors = ["Adam Becker <im.adam.becker@gmail.com>"]
+version = "0.1.3"
+authors = ["Adam Becker <apbecker@protonmail.com>"]
 edition = "2021"
 
 [dependencies]

--- a/libretro-rs/src/core_macro.rs
+++ b/libretro-rs/src/core_macro.rs
@@ -37,7 +37,7 @@ macro_rules! libretro_core {
 
       #[no_mangle]
       extern "C" fn retro_init() {
-        instance_mut(|instance| instance.on_init())
+        instance_ref(|instance| instance.on_init())
       }
 
       #[no_mangle]


### PR DESCRIPTION
Addesses [Issue #3: Move RetroCore instantiation to load_game for better ergonomics](https://github.com/libretro-rs/libretro-rs/issues/3). Below is a summary of the changes:
- `retro_init` and `retro_deinit` are now no-ops.
- Removed `RetroCore::init`.
- `RetroLoadGameResult` contains an additional field for the `RetroCore` instance.
- `RetroCore::load_game` is now a function.
- Removed `RetroInstance::on_init` and `on_deinit`. The code has been moved to `on_load_game` and `on_unload_game` respectively.

With these changes, users of the crate return a fully initialized instance from `RetroCore::load_game` rather than return a partially initialized instance from `init` and updating it in `load_game`.

Since this isn't a backwards-compatible change, I've updated the minor digit of the version number.