### PR TITLE
Add public constructor for RetroDevicePort.

### DIFF
--- a/libretro-rs/src/lib.rs
+++ b/libretro-rs/src/lib.rs
@@ -3,6 +3,7 @@ pub use libretro_rs_sys as sys;
 pub mod core_macro;
 
 use std::ffi::{CStr, CString};
+use libretro_rs_sys::libc::c_uint;
 use sys::*;
 
 #[allow(unused_variables)]
@@ -107,16 +108,27 @@ impl TryFrom<u32> for RetroDevice {
   }
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct RetroDevicePort(u32);
+/// A libretro device port.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RetroDevicePort(c_uint);
 
 impl RetroDevicePort {
-  pub fn new(port_num: u32) -> Self {
-    RetroDevicePort(port_num)
+  /// Creates a [RetroDevicePort].
+  pub fn new(port_number: u8) -> Self {
+    RetroDevicePort(c_uint::from(port_number))
   }
+}
 
-  pub fn into_inner(self) -> u32 {
-    self.0
+impl From<u8> for RetroDevicePort {
+  fn from(port_number: u8) -> Self {
+    Self::new(port_number)
+  }
+}
+
+impl From<RetroDevicePort> for c_uint {
+  fn from(port: RetroDevicePort) -> Self {
+    port.0
   }
 }
 

--- a/libretro-rs/src/lib.rs
+++ b/libretro-rs/src/lib.rs
@@ -111,6 +111,10 @@ impl TryFrom<u32> for RetroDevice {
 pub struct RetroDevicePort(u32);
 
 impl RetroDevicePort {
+  pub fn new(port_num: u32) -> Self {
+    RetroDevicePort(port_num)
+  }
+
   pub fn into_inner(self) -> u32 {
     self.0
   }

--- a/libretro-rs/src/lib.rs
+++ b/libretro-rs/src/lib.rs
@@ -3,7 +3,6 @@ pub use libretro_rs_sys as sys;
 pub mod core_macro;
 
 use std::ffi::{CStr, CString};
-use libretro_rs_sys::libc::c_uint;
 use sys::*;
 
 #[allow(unused_variables)]
@@ -111,12 +110,17 @@ impl TryFrom<u32> for RetroDevice {
 /// A libretro device port.
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct RetroDevicePort(c_uint);
+pub struct RetroDevicePort(u8);
 
 impl RetroDevicePort {
   /// Creates a [RetroDevicePort].
   pub fn new(port_number: u8) -> Self {
-    RetroDevicePort(c_uint::from(port_number))
+    RetroDevicePort(port_number)
+  }
+
+  // Converts this port back into a u8.
+  pub fn into_inner(self) -> u8 {
+    self.0
   }
 }
 
@@ -126,9 +130,9 @@ impl From<u8> for RetroDevicePort {
   }
 }
 
-impl From<RetroDevicePort> for c_uint {
+impl From<RetroDevicePort> for u8 {
   fn from(port: RetroDevicePort) -> Self {
-    port.0
+    port.into_inner()
   }
 }
 
@@ -455,12 +459,11 @@ impl RetroRuntime {
       .input_state
       .expect("`is_joypad_button_pressed` called without registering an `input_state` callback");
 
+    let port = libc::c_uint::from(port.into_inner());
+    let device = RETRO_DEVICE_JOYPAD;
+    let index = 0;
+    let id = btn.into();
     unsafe {
-      let port = port.0;
-      let device = RETRO_DEVICE_JOYPAD;
-      let index = 0;
-      let id = btn.into();
-
       cb(port, device, index, id) != 0
     }
   }
@@ -658,9 +661,11 @@ impl<T: RetroCore> RetroInstance<T> {
   /// Invoked by a `libretro` frontend, with the `retro_set_controller_port_device` API call.
   pub fn on_set_controller_port_device(&mut self, port: libc::c_uint, device: libc::c_uint) {
     if let Ok(device) = device.try_into() {
-      let mut env = self.environment();
-      let port = RetroDevicePort(port);
-      self.core_mut(|core| core.set_controller_port_device(&mut env, port, device))
+      if let Ok(port_num) = u8::try_from(port) {
+        let mut env = self.environment();
+        let port = RetroDevicePort(port_num);
+        self.core_mut(|core| core.set_controller_port_device(&mut env, port, device))
+      }
     }
   }
 


### PR DESCRIPTION
Addresses [Issue #6: Can't call RetroRuntime::is_joypad_button_pressed](https://github.com/libretro-rs/libretro-rs/issues/6).