### PR TITLE
Expose all retro_* callbacks in RetroCore.

### DIFF
--- a/example/src/cpu.rs
+++ b/example/src/cpu.rs
@@ -182,14 +182,14 @@ impl Cpu {
       // 8xy4 - ADD Vx, Vy
       (0x8, _, _, 0x4) => {
         let (result, overflow) = self.get(code.x()).overflowing_add(self.get(code.y()));
-        self.set(code.f(), if overflow { 1 } else { 0 });
+        self.set(code.f(), u8::from(overflow));
         self.set(code.x(), result);
       }
 
       // 8xy5 - SUB Vx, Vy
       (0x8, _, _, 0x5) => {
         let (result, overflow) = self.get(code.x()).overflowing_sub(self.get(code.y()));
-        self.set(code.f(), if overflow { 1 } else { 0 });
+        self.set(code.f(), u8::from(overflow));
         self.set(code.x(), result)
       }
 
@@ -202,7 +202,7 @@ impl Cpu {
       // 8xy7 - SUBN Vx, Vy
       (0x8, _, _, 0x7) => {
         let (result, overflow) = self.get(code.y()).overflowing_sub(self.get(code.x()));
-        self.set(code.f(), if overflow { 1 } else { 0 });
+        self.set(code.f(), u8::from(overflow));
         self.set(code.x(), result);
       }
 
@@ -242,7 +242,7 @@ impl Cpu {
         let vy = self.get(code.y()) as usize;
         let collisions = self.display.drw(vx, vy, &sprite_data);
 
-        self.set(code.f(), if collisions { 1 } else { 0 });
+        self.set(code.f(), u8::from(collisions));
       }
 
       // Ex9E - SKP Vx

--- a/example/src/memory.rs
+++ b/example/src/memory.rs
@@ -18,7 +18,7 @@ impl Memory {
   pub fn new(game: &[u8]) -> Memory {
     let mut data = [0; MEMORY_SIZE];
     data[0x000..0x000 + FONT.len()].copy_from_slice(&FONT);
-    data[0x200..0x200 + game.len()].copy_from_slice(&game);
+    data[0x200..0x200 + game.len()].copy_from_slice(game);
 
     Memory { data }
   }

--- a/libretro-rs-sys/build.rs
+++ b/libretro-rs-sys/build.rs
@@ -3,7 +3,7 @@ extern crate bindgen;
 use std::env;
 use std::path::PathBuf;
 
-const LIBRETRO_HEADER_FILE: &'static str = "include/libretro.h";
+const LIBRETRO_HEADER_FILE: &str = "include/libretro.h";
 
 fn main() {
   println!("cargo:rerun-if-changed={}", LIBRETRO_HEADER_FILE);
@@ -13,6 +13,7 @@ fn main() {
     .allowlist_type("^retro_.+$")
     .allowlist_var("^RETRO_.+$")
     .default_enum_style(bindgen::EnumVariation::Rust { non_exhaustive: false })
+    .derive_default(true)
     .layout_tests(true)
     .parse_callbacks(Box::new(bindgen::CargoCallbacks))
     .generate()

--- a/libretro-rs/src/av_info.rs
+++ b/libretro-rs/src/av_info.rs
@@ -2,7 +2,7 @@ use core::ffi::*;
 use core::ops::*;
 use libretro_rs_sys::*;
 
-/// Rust interface for [retro_system_av_info].
+/// Rust interface for [`retro_system_av_info`].
 #[repr(transparent)]
 #[derive(Debug, Clone)]
 pub struct RetroSystemAVInfo(retro_system_av_info);
@@ -16,7 +16,7 @@ impl RetroSystemAVInfo {
     })
   }
 
-  /// Returns a [RetroSystemAVInfo] with the default [RetroSystemTiming].
+  /// Returns a [`RetroSystemAVInfo`] with the default [`RetroSystemTiming`].
   pub fn default_timings(geometry: RetroGameGeometry) -> Self {
     Self::new(geometry, RetroSystemTiming::default())
   }
@@ -52,13 +52,13 @@ impl From<RetroSystemAVInfo> for retro_system_av_info {
   }
 }
 
-/// Rust interface for [retro_game_geometry].
+/// Rust interface for [`retro_game_geometry`].
 #[repr(transparent)]
 #[derive(Clone, Debug)]
 pub struct RetroGameGeometry(retro_game_geometry);
 
 impl RetroGameGeometry {
-  /// Creates a [retro_game_geometry] with fixed width and height and automatically
+  /// Creates a [`retro_game_geometry`] with fixed width and height and automatically
   /// derived aspect ratio.
   pub fn fixed(width: u16, height: u16) -> Self {
     Self(retro_game_geometry {
@@ -70,7 +70,7 @@ impl RetroGameGeometry {
     })
   }
 
-  /// Creates a [retro_game_geometry] with the given base and max width and height,
+  /// Creates a [`retro_game_geometry`] with the given base and max width and height,
   /// and automatically derived aspect ratio.
   pub fn variable(width: RangeInclusive<u16>, height: RangeInclusive<u16>) -> Self {
     Self::new(width, height, 0.0)
@@ -130,7 +130,7 @@ impl From<RetroGameGeometry> for retro_game_geometry {
   }
 }
 
-/// Rust interface for [retro_system_timing].
+/// Rust interface for [`retro_system_timing`].
 #[repr(transparent)]
 #[derive(Clone, Debug)]
 pub struct RetroSystemTiming(retro_system_timing);

--- a/libretro-rs/src/av_info.rs
+++ b/libretro-rs/src/av_info.rs
@@ -1,0 +1,183 @@
+use core::ffi::*;
+use core::ops::*;
+use libretro_rs_sys::*;
+
+/// Rust interface for [retro_system_av_info].
+#[repr(transparent)]
+#[derive(Debug, Clone)]
+pub struct RetroSystemAVInfo(retro_system_av_info);
+
+impl RetroSystemAVInfo {
+  /// Main constructor.
+  pub fn new(geometry: RetroGameGeometry, timing: RetroSystemTiming) -> Self {
+    Self(retro_system_av_info {
+      geometry: geometry.into(),
+      timing: timing.into(),
+    })
+  }
+
+  /// Returns a [RetroSystemAVInfo] with the default [RetroSystemTiming].
+  pub fn default_timings(geometry: RetroGameGeometry) -> Self {
+    Self::new(geometry, RetroSystemTiming::default())
+  }
+
+  pub fn geometry(&self) -> RetroGameGeometry {
+    RetroGameGeometry(self.0.geometry)
+  }
+
+  pub fn timing(&self) -> RetroSystemTiming {
+    RetroSystemTiming(self.0.timing)
+  }
+
+  pub fn into_inner(self) -> retro_system_av_info {
+    self.0
+  }
+}
+
+impl AsRef<retro_system_av_info> for RetroSystemAVInfo {
+  fn as_ref(&self) -> &retro_system_av_info {
+    &self.0
+  }
+}
+
+impl AsMut<retro_system_av_info> for RetroSystemAVInfo {
+  fn as_mut(&mut self) -> &mut retro_system_av_info {
+    &mut self.0
+  }
+}
+
+impl From<RetroSystemAVInfo> for retro_system_av_info {
+  fn from(av_info: RetroSystemAVInfo) -> Self {
+    av_info.into_inner()
+  }
+}
+
+/// Rust interface for [retro_game_geometry].
+#[repr(transparent)]
+#[derive(Clone, Debug)]
+pub struct RetroGameGeometry(retro_game_geometry);
+
+impl RetroGameGeometry {
+  /// Creates a [retro_game_geometry] with fixed width and height and automatically
+  /// derived aspect ratio.
+  pub fn fixed(width: u16, height: u16) -> Self {
+    Self(retro_game_geometry {
+      base_width: width.into(),
+      base_height: height.into(),
+      max_width: width.into(),
+      max_height: height.into(),
+      aspect_ratio: 0.0,
+    })
+  }
+
+  /// Creates a [retro_game_geometry] with the given base and max width and height,
+  /// and automatically derived aspect ratio.
+  pub fn variable(width: RangeInclusive<u16>, height: RangeInclusive<u16>) -> Self {
+    Self::new(width, height, 0.0)
+  }
+
+  /// Main constructor.
+  pub fn new(width: RangeInclusive<u16>, height: RangeInclusive<u16>, aspect_ratio: f32) -> Self {
+    Self(retro_game_geometry {
+      base_width: c_uint::from(*width.start()),
+      base_height: c_uint::from(*height.start()),
+      max_width: c_uint::from(*width.end()),
+      max_height: c_uint::from(*height.end()),
+      aspect_ratio,
+    })
+  }
+
+  pub fn base_width(&self) -> u16 {
+    self.0.base_width as u16
+  }
+
+  pub fn base_height(&self) -> u16 {
+    self.0.base_height as u16
+  }
+
+  pub fn max_width(&self) -> u16 {
+    self.0.max_width as u16
+  }
+
+  pub fn max_height(&self) -> u16 {
+    self.0.max_height as u16
+  }
+
+  pub fn aspect_ratio(&self) -> f32 {
+    self.0.aspect_ratio
+  }
+
+  pub fn into_inner(self) -> retro_game_geometry {
+    self.0
+  }
+}
+
+impl AsRef<retro_game_geometry> for RetroGameGeometry {
+  fn as_ref(&self) -> &retro_game_geometry {
+    &self.0
+  }
+}
+
+impl AsMut<retro_game_geometry> for RetroGameGeometry {
+  fn as_mut(&mut self) -> &mut retro_game_geometry {
+    &mut self.0
+  }
+}
+
+impl From<RetroGameGeometry> for retro_game_geometry {
+  fn from(geometry: RetroGameGeometry) -> Self {
+    geometry.into_inner()
+  }
+}
+
+/// Rust interface for [retro_system_timing].
+#[repr(transparent)]
+#[derive(Clone, Debug)]
+pub struct RetroSystemTiming(retro_system_timing);
+
+impl RetroSystemTiming {
+  /// Main constructor.
+  pub fn new(fps: f64, sample_rate: f64) -> Self {
+    Self(retro_system_timing { fps, sample_rate })
+  }
+
+  pub fn fps(&self) -> f64 {
+    self.0.fps
+  }
+
+  pub fn sample_rate(&self) -> f64 {
+    self.0.sample_rate
+  }
+
+  pub fn into_inner(self) -> retro_system_timing {
+    self.0
+  }
+}
+
+impl Default for RetroSystemTiming {
+  /// 60.0 FPS and 44.1khz sample rate.
+  fn default() -> Self {
+    Self(retro_system_timing {
+      fps: 60.0,
+      sample_rate: 44_100.0,
+    })
+  }
+}
+
+impl AsRef<retro_system_timing> for RetroSystemTiming {
+  fn as_ref(&self) -> &retro_system_timing {
+    &self.0
+  }
+}
+
+impl AsMut<retro_system_timing> for RetroSystemTiming {
+  fn as_mut(&mut self) -> &mut retro_system_timing {
+    &mut self.0
+  }
+}
+
+impl From<RetroSystemTiming> for retro_system_timing {
+  fn from(timing: RetroSystemTiming) -> Self {
+    timing.into_inner()
+  }
+}

--- a/libretro-rs/src/memory.rs
+++ b/libretro-rs/src/memory.rs
@@ -38,18 +38,17 @@ where
 
   /// Attempts to convert a [u16] into a known [RetroMemoryType].
   fn try_from(mem_type: u16) -> Result<Self, Self::Error> {
-    use RetroMemoryType::*;
     match mem_type {
-      0 => Ok(SaveRam),
-      1 => Ok(RTC),
-      2 => Ok(SystemRam),
-      3 => Ok(VideoRam),
+      0 => Ok(Self::SaveRam),
+      1 => Ok(Self::RTC),
+      2 => Ok(Self::SystemRam),
+      3 => Ok(Self::VideoRam),
       _ => {
         if mem_type < 256 {
           Err("Unknown standard memory type")
         } else {
           T::from_discriminant((mem_type >> 8) as u8)
-            .map(|mem_type| Subsystem(mem_type))
+            .map(|mem_type| Self::Subsystem(mem_type))
             .ok_or("Unknown subsystem memory type")
         }
       }

--- a/libretro-rs/src/memory.rs
+++ b/libretro-rs/src/memory.rs
@@ -1,0 +1,58 @@
+use crate::RetroTypeId;
+
+/// Enum for the `RETRO_MEMORY_*` constants in `libretro.h`, as well as
+/// user-defined subsystem memory types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RetroMemoryType<T> {
+  SaveRam,
+  RTC,
+  SystemRam,
+  VideoRam,
+  Subsystem(T),
+}
+
+impl<T> From<RetroMemoryType<T>> for u16
+where
+  T: RetroTypeId,
+{
+  /// Converts the standard memory types back into their constants, and
+  /// left-shifts subsystem memory types to the upper 8 bits as recommended
+  /// by the libretro API to avoid conflicts with future memory types.
+  fn from(mem_type: RetroMemoryType<T>) -> Self {
+    use RetroMemoryType::*;
+    match mem_type {
+      SaveRam => 0,
+      RTC => 1,
+      SystemRam => 2,
+      VideoRam => 3,
+      Subsystem(subsystem_type) => (subsystem_type.into_discriminant() as u16) << 8,
+    }
+  }
+}
+
+impl<T> TryFrom<u16> for RetroMemoryType<T>
+where
+  T: RetroTypeId,
+{
+  type Error = &'static str;
+
+  /// Attempts to convert a [u16] into a known [RetroMemoryType].
+  fn try_from(mem_type: u16) -> Result<Self, Self::Error> {
+    use RetroMemoryType::*;
+    match mem_type {
+      0 => Ok(SaveRam),
+      1 => Ok(RTC),
+      2 => Ok(SystemRam),
+      3 => Ok(VideoRam),
+      _ => {
+        if mem_type < 256 {
+          Err("Unknown standard memory type")
+        } else {
+          T::from_discriminant((mem_type >> 8) as u8)
+            .map(|mem_type| Subsystem(mem_type))
+            .ok_or("Unknown subsystem memory type")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Exposes all `retro_*` callbacks in `RetroCore`. This is necessary to future-proof the crate's API, since environment commands can be specific to certain callbacks. In my opinion it also makes the crate easier to learn since it'll have a close mapping to the C API.

Also makes some slight alterations to the existing `RetroCore` methods, like removing the redundant `size` parameter and using associated types instead of just `u32` for user-defined enums.