### PR TITLE
Remove associated types from RetroCore trait.

### DIFF
--- a/example/src/libretro.rs
+++ b/example/src/libretro.rs
@@ -65,9 +65,6 @@ fn key_to_retro_button(key: keyboard::Key) -> RetroJoypadButton {
 }
 
 impl RetroCore for LibretroCore {
-  type SpecialGameType = ();
-  type SubsystemMemoryType = ();
-
   fn get_system_info() -> RetroSystemInfo {
     RetroSystemInfo::new("chip8.rs", env!("CARGO_PKG_VERSION"))
   }

--- a/libretro-rs/src/core_macro.rs
+++ b/libretro-rs/src/core_macro.rs
@@ -121,7 +121,7 @@ macro_rules! libretro_core {
       }
 
       #[no_mangle]
-      extern "C" fn retro_load_game_special(game_type: libc::c_uint, info: &retro_game_info, num_info: libc::size_t) -> bool {
+      extern "C" fn retro_load_game_special(game_type: RetroGameType, info: &retro_game_info, num_info: libc::size_t) -> bool {
         instance_mut(|instance| instance.on_load_game_special(game_type, info, num_info))
       }
 
@@ -136,12 +136,12 @@ macro_rules! libretro_core {
       }
 
       #[no_mangle]
-      extern "C" fn retro_get_memory_data(id: libc::c_uint) -> *mut () {
+      extern "C" fn retro_get_memory_data(id: RetroMemoryType) -> *mut () {
         instance_mut(|instance| instance.on_get_memory_data(id))
       }
 
       #[no_mangle]
-      extern "C" fn retro_get_memory_size(id: libc::c_uint) -> libc::size_t {
+      extern "C" fn retro_get_memory_size(id: RetroMemoryType) -> libc::size_t {
         instance_mut(|instance| instance.on_get_memory_size(id))
       }
 


### PR DESCRIPTION
This is a follow-up to #20. The two associated types that were introduced in that PR have been replaced with type parameters with defaults. With this change, users that don't need `load_game_special` or `get_memory` are no longer required to explicitly define types for parameters to methods they don't implement.